### PR TITLE
Fix view is updated unintentionally when inputting words via input method

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1,12 +1,28 @@
 <template>
   <div class="prism-editor-wrapper">
-    <div class="prism-editor__line-numbers" aria-hidden="true" v-if="lineNumbers" :style="{'min-height': lineNumbersHeight}">
-      <div class="prism-editor__line-width-calc" style="height: 0px; visibility: hidden; pointer-events: none;">999</div>
-      <div class="prism-editor__line-number token comment" v-for="line in lineNumbersCount" :key="line">{{line}}</div>
+    <div
+      class="prism-editor__line-numbers"
+      aria-hidden="true"
+      v-if="lineNumbers"
+      :style="{ 'min-height': lineNumbersHeight }"
+    >
+      <div
+        class="prism-editor__line-width-calc"
+        style="height: 0px; visibility: hidden; pointer-events: none;"
+      >
+        999
+      </div>
+      <div
+        class="prism-editor__line-number token comment"
+        v-for="line in lineNumbersCount"
+        :key="line"
+      >
+        {{ line }}
+      </div>
     </div>
     <pre
       class="prism-editor__code"
-      :class="{['language-'+language]: true}"
+      :class="{ ['language-' + language]: true }"
       ref="pre"
       v-html="content"
       :contenteditable="!readonly"
@@ -18,7 +34,7 @@
       autocomplete="off"
       autocorrect="off"
       data-gramm="false"
-      ></pre>
+    ></pre>
   </div>
 </template>
 
@@ -140,6 +156,13 @@ export default {
     $pre.addEventListener("paste", onPaste);
     this.$once("hook:beforeDestroy", () => {
       $pre.removeEventListener("paste", onPaste);
+    });
+    $pre.addEventListener("compositionstart", () => {
+      this.composing = true;
+    });
+    $pre.addEventListener("compositionend", () => {
+      // for canceling input.
+      this.composing = false;
     });
   },
 
@@ -304,6 +327,18 @@ export default {
       }
     },
     handleKeyUp(evt) {
+      const keyupCode = evt.which;
+      if (this.composing) {
+        if (keyupCode === 13) {
+          // finish inputting via IM.
+          this.composing = false;
+        } else {
+          // now inputting words using IM.
+          // must not update view.
+          return;
+        }
+      }
+
       if (this.emitEvents) {
         this.$emit("keyup", evt);
       }
@@ -340,7 +375,6 @@ export default {
   }
 };
 </script>
-
 
 <style>
 .prism-editor-wrapper code {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -85,7 +85,8 @@ export default {
       undoOffset: 0,
       undoTimestamp: 0,
       lastPos: 0,
-      codeData: ""
+      codeData: "",
+      composing: false
     };
   },
   watch: {


### PR DESCRIPTION
Hi,

I found the issue when inputting words using Input method. See below screen capture.
![2019-04-03 18-18-32 2019-04-03 18_19_09](https://user-images.githubusercontent.com/195194/55469098-b4eefb80-563f-11e9-82b0-61a669389472.gif)

So I fixed and the result is
![2019-04-03 18-27-08 2019-04-03 18_28_44](https://user-images.githubusercontent.com/195194/55469168-db149b80-563f-11e9-8946-182807ee6f2f.gif)

Changes are
- Add composition state using [CompositionEvent](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent)
- When composition started, ignore keyup events until composition end which results to forbid view update.
- Template tag part has no modification. May be affect of git pre-commit hook.