### PR TITLE
Fix locally registering part of manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ Register the component locally and use it (recommended)
 
 ```html
 <template>
-  <prism-editor :code="code" language="js"></prism-editor>
+  <prism-editor v-model="code" language="js"></prism-editor>
 </template>
 
 <script>
+import 'prismjs'
+import 'prismjs/themes/prism.css'
+import 'vue-prism-editor/dist/VuePrismEditor.css'  
 import PrismEditor from 'vue-prism-editor'
+  
 export default {
   components: {
     PrismEditor


### PR DESCRIPTION
The manual for locally registering the component was incomplete.
Using the :code prop breaks the syntax highlighting, if you use v-model, it works.