### PR TITLE
Feature: custom render

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,16 @@ OR:
 
 ## Props
 
-| Name                 | Type      | Default | Options                              | Description                                           |
-| -------------------- | --------- | ------- | ------------------------------------ | ----------------------------------------------------- |
-| v-model              | `string`  | -       | -                                    | for the `code` prop below                             |
-| code                 | `string`  | `""`    | -                                    | the code                                              |
-| language             | `String`  | `"js"`  | `vue,html,md,ts` + Prismjs Languages | language of the code                                  |
-| lineNumbers          | `Boolean` | `false` | -                                    | Whether to show line numbers or not                   |
-| readonly             | `Boolean` | `false` | -                                    | Indicates if the editor is read only or not.          |
-| emitEvents           | `Boolean` | `false` | -                                    | Indicates if the editor should emit events.           |
-| autoStyleLineNumbers | `Boolean` | `true`  | -                                    | Allow the line number to be styled by this component. |
+| Name                 | Type       | Default | Options                              | Description                                           |
+| -------------------- | ---------- | ------- | ------------------------------------ | ----------------------------------------------------- |
+| v-model              | `string`   | -       | -                                    | for the `code` prop below                             |
+| code                 | `string`   | `""`    | -                                    | the code                                              |
+| language             | `String`   | `"js"`  | `vue,html,md,ts` + Prismjs Languages | language of the code                                  |
+| lineNumbers          | `Boolean`  | `false` | -                                    | Whether to show line numbers or not                   |
+| readonly             | `Boolean`  | `false` | -                                    | Indicates if the editor is read only or not.          |
+| emitEvents           | `Boolean`  | `false` | -                                    | Indicates if the editor should emit events.           |
+| autoStyleLineNumbers | `Boolean`  | `true`  | -                                    | Allow the line number to be styled by this component. |
+| highlight            | `Function` | `prism` | -                                    | Customize the highlighting of the code                |
 
 ## Events
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,16 +10,16 @@
           </h3>
         </div>
         <div class="hero-options my-8 w-64 max-w-sm sm:w-full mx-auto">
-          <label for="ln" class="">
+          <label class="">
             <input type="checkbox" name="ln" v-model="lineNumbers" />
             Line Numbers
           </label>
-          <label for="ln" class="ml-4">
-            <input type="checkbox" name="ln" v-model="readonly" />
+          <label class="ml-4">
+            <input type="checkbox" name="cb" v-model="readonly" />
             Readonly
           </label>
-          <label for="ln" class="ml-4">
-            <input type="checkbox" name="ln" v-model="customHighlight" />
+          <label class="ml-4">
+            <input type="checkbox" name="ch" v-model="customHighlight" />
             Custom Highlight
           </label>
         </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,10 @@
             <input type="checkbox" name="ln" v-model="readonly" />
             Readonly
           </label>
+          <label for="ln" class="ml-4">
+            <input type="checkbox" name="ln" v-model="customHighlight" />
+            Custom Highlight
+          </label>
         </div>
         <div class="hero-info">
           Documentation on
@@ -32,6 +36,7 @@
         v-model="code"
         :line-numbers="lineNumbers"
         :readonly="readonly"
+        :highlight="customHighlight ? highlight : undefined"
       ></Editor>
     </main>
   </div>
@@ -52,6 +57,7 @@ export default {
   data: () => ({
     lineNumbers: true,
     readonly: false,
+    customHighlight: false,
     /* eslint-disable */
     code: `<template>
   <div id="app">
@@ -74,6 +80,11 @@ export default {
   }),
   mounted() {
     console.log(Prism);
+  },
+  methods: {
+    highlight(src) {
+      return src.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    }
   }
 };
 </script>

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -77,6 +77,10 @@ export default {
     code: {
       type: String,
       default: ""
+    },
+    highlight: {
+      type: Function,
+      default: prism
     }
   },
   data() {
@@ -121,7 +125,7 @@ export default {
   },
   computed: {
     content() {
-      return prism(this.codeData || "", this.language);
+      return this.highlight(this.codeData || "", this.language);
     },
     lineNumbersCount() {
       let totalLines = this.codeData.split(/\r\n|\n/).length;


### PR DESCRIPTION
In vue-live and to simplify the reading of examples, we have a pseudo-jsx language not supported by prism.

Essentially it's JS until the first "<" sign.

To avoid odd bugs, I added a highlight prop. It expects a function exactly with the same prototype as `prism`: `function highlight(sourceCode, language)` and return html highlighted code.

Thank you in advance.