### PR TITLE
Listen to scroll event on preview component

### DIFF
--- a/packages/vue-prism-editor/src/Editor.ts
+++ b/packages/vue-prism-editor/src/Editor.ts
@@ -278,6 +278,11 @@ export const PrismEditor = Vue.extend({
       this.$emit('input', value);
       // this.props.onValueChange(value);
     },
+    handleScroll(e: Event): void {
+      const editor = this.$refs.pre as HTMLTextAreaElement;
+
+      (this.$refs.textarea as HTMLTextAreaElement).scrollTop = editor.scrollTop;
+    },
     _undoEdit(): void {
       const { stack, offset } = this.history;
 
@@ -547,6 +552,7 @@ export const PrismEditor = Vue.extend({
       on: {
         input: this.handleChange,
         keydown: this.handleKeyDown,
+        scroll: this.handleScroll,
         click: ($event: MouseEvent) => {
           this.$emit('click', $event);
         },


### PR DESCRIPTION
I wasn't able to test this, but it should allow the editor component to scroll vertically. Currently, when a height is set to the editor component, it won't scroll past the editor.