### PR TITLE
Fix issue with global var for Vue 2

### DIFF
--- a/packages/vue-prism-editor/src/Editor.ts
+++ b/packages/vue-prism-editor/src/Editor.ts
@@ -16,8 +16,8 @@ const KEYCODE_ESCAPE = 27;
 const HISTORY_LIMIT = 100;
 const HISTORY_TIME_GAP = 3000;
 
-const isWindows = 'navigator' in global && /Win/i.test(navigator.platform);
-const isMacLike = 'navigator' in global && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+const isWindows = typeof window !== 'undefined' && navigator && /Win/i.test(navigator.platform);
+const isMacLike = typeof window !== 'undefined' && navigator && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
 
 export interface EditorProps {
   lineNumbers: boolean;


### PR DESCRIPTION
Thanks for your work on this component! I'm still using Vue 2 and have trouble getting it to run with VuePress, presumably because of this issue with the global var that has been fixed for v2.0.0.  Can we backport this for v1? That would be amazing!