### PR TITLE
Fix unsafe-inline CSP Style violation

### DIFF
--- a/packages/vue-prism-editor/src/Editor.ts
+++ b/packages/vue-prism-editor/src/Editor.ts
@@ -516,9 +516,13 @@ export const PrismEditor = Vue.extend({
     const lineNumberWidthCalculator = h(
       'div',
       {
+        style: {
+          'height': '0px',
+          'visibility': 'hidden',
+          'pointer-events': 'none',
+        },
         attrs: {
           class: 'prism-editor__line-width-calc',
-          style: 'height: 0px; visibility: hidden; pointer-events: none;',
         },
       },
       '999'


### PR DESCRIPTION
Move attrs -> style to just style on lineNumberWidthCalculator
Avoids violating CSP style policy of 'self'